### PR TITLE
Add new states with icons. Fixes #7

### DIFF
--- a/simple-thermostat.js
+++ b/simple-thermostat.js
@@ -138,7 +138,7 @@ const STATE_ICONS = {
   cool: 'mdi:snowflake',
   auto: 'mdi:radiator',
   manual: 'mdi:radiator',
-  boost: 'mdi:radiator',
+  boost: 'mdi:fire',
   away: 'mdi:radiator-disabled'
 }
 
@@ -314,7 +314,7 @@ class SimpleThermostat extends LitElement {
       <header>
         ${ icon && html`
           <ha-icon class="icon" .icon=${icon}></ha-icon>
-        `}
+        ` || '' }
         <h2 class="title">
         ${this.name}
         </h2>

--- a/simple-thermostat.js
+++ b/simple-thermostat.js
@@ -132,9 +132,14 @@ const modeIcons = {
 
 const STATE_ICONS = {
   off: 'mdi:radiator-off',
+  on: 'mdi:radiator',
   idle: 'mdi:radiator-disabled',
   heat: 'mdi:radiator',
   cool: 'mdi:snowflake',
+  auto: 'mdi:radiator',
+  manual: 'mdi:radiator',
+  boost: 'mdi:radiator',
+  away: 'mdi:radiator-disabled'
 }
 
 const DEFAULT_HIDE = {


### PR DESCRIPTION
As described in #7, this commit adds the missing icons for all available states for the eq3btsmart thermostats.

I'm not sure if this is the right way to go, since I'm not sure how unique these states are for my radiator. However, that's what fixes it for me so I figured it might fix this for other people as well. An alternative would be to just add a default icon if there's no match.