### PR TITLE
Updated for changes in HA 0.96

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class SimpleThermostat extends LitElement {
     this._mode = null
     this._hide = DEFAULT_HIDE
     this._haVersion = null
-    this.modeType = 'operation'
+    this.modeType = 'hvac'
   }
 
   setConfig(config) {
@@ -116,7 +116,7 @@ class SimpleThermostat extends LitElement {
     const {
       attributes: {
         [`${this.modeType}_mode`]: mode,
-        [`${this.modeType}_list`]: modes = [],
+        [`${this.modeType}_modes`]: modes = [],
         ...attributes
       },
     } = entity
@@ -244,7 +244,6 @@ class SimpleThermostat extends LitElement {
         min_temp: minTemp = null,
         max_temp: maxTemp = null,
         current_temperature: current,
-        [`${this.modeType}_mode`]: activeMode,
         ...attributes
       },
     } = entity
@@ -306,7 +305,7 @@ class SimpleThermostat extends LitElement {
             `
           })}
         </section>
-        ${this.renderModeSelector(activeMode)}
+        ${this.renderModeSelector(state)}
       </ha-card>
     `
   }


### PR DESCRIPTION
From the home assistant devs: 
- `operation_mode` has been renamed to `hvac_mode` to emphasize what the mode is for.
- Property names have been aligned, anything ending with "_list" is now named "_modes"

In practice it looks like they only added `hvac_modes` to replace `operation_modes` (the array of all modes). There is no attribute `hvac_mode` to replace `operation_mode` for storing the current mode. I decided to pull current mode from the entity state instead. I'm not sure if state could ever be different from `hvac_mode`, but it worked for my thermostat. I just have Cool, Heat, Auto, and Off.

See https://developers.home-assistant.io/blog/2019/07/03/climate-cleanup.html

