### PR TITLE
Allow setting HVAC mode through MQTT

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -465,10 +465,17 @@ class SimpleThermostat extends LitElement {
 
   setMode(mode) {
     if (mode && mode !== this._mode) {
-      this._hass.callService('climate', `set_${this.modeType}_mode`, {
-        entity_id: this.config.entity,
-        [`${this.modeType}_mode`]: mode,
-      })
+      if (this.config.mqtt && this.config.mqtt.mode_topic) {
+        this._hass.callService('mqtt', 'publish', {
+          topic: this.config.mqtt.mode_topic,
+          payload: mode,
+        })
+      } else {
+        this._hass.callService('climate', `set_${this.modeType}_mode`, {
+          entity_id: this.config.entity,
+          [`${this.modeType}_mode`]: mode,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
I'm not sure you'd be wiling to accept this feature request in any form because basically this is a workaround for recent HA changes 😆, but I'm wiling to try anyway, no hard feelings if you close it. But if you or community will find it useful I'm wiling to add documentation.

The problem is that since 0.96 HA does not allow custom HVAC modes outside of this list: https://github.com/home-assistant/home-assistant/blob/0.96.0/homeassistant/components/climate/const.py#L25-L33

But I have a few MQTT-based thermostats which are harder to tweak into mapping only to the allowed modes. This change allows to specify the MQTT topic where to send mode change command to, which works around the problem beautifully IMHO.

Here's my card definition:

```yaml
type: 'custom:simple-thermostat'
entity: climate.thermostat_bedroom_climate
sensors:
  - entity: sensor.0x00158d0002f2ed69_humidity
    name: Humidity
hide:
  away: false
mqtt:
  mode_topic: support/thermostat/bedroom/mode/set
```

And a screenshot of mode called "manual" actually working:

<img width="507" alt="Home Assistant 2019-09-11 00-07-35" src="https://user-images.githubusercontent.com/944286/64651272-c37ce280-d429-11e9-879b-0fc4a5b75e87.png">
