### PR TITLE
Add variable for background of inactive buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The card uses the following CSS variables:
 | --st-spacing                | 4px                                     | Base unit for spacing. Used in multiples many places |
 | --st-mode-active-background | var(--primary-color)                    | Background color for active mode button              |
 | --st-mode-active-color      | var(--text-primary-color, #fff)         | Text color for active mode button                    |
+| --st-mode-background        | #dff4fd                                 | Background color for inactive mode button            |
 
 ### Example tweaking with card-modder
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -11,6 +11,7 @@ export default css`
     --st-spacing: 4px;
     --st-mode-active-background: var(--primary-color);
     --st-mode-active-color: #fff;
+    --st-mode-background: #dff4fd;
   }
 
   ha-card {
@@ -136,7 +137,7 @@ export default css`
     justify-content: center;
     min-height: 24px;
     padding: var(--st-spacing) 0;
-    background: #dff4fd;
+    background: var(--st-mode-background);
     color: var(--sidebar-selected-icon-color);
     cursor: pointer;
     border-radius: var(--st-spacing);


### PR DESCRIPTION
When using the simple-thermostat card with dark themes in Home Assistant (for example at night), the inactive buttons still keep their bright background color (default: `#dff4fd`).

### Before: 

![image](https://user-images.githubusercontent.com/23156476/68518877-3d94e080-028e-11ea-9a7d-57c97d9696bf.png)

With the addition of a new CSS variable `--st-mode-background`, the background color can be altered by the [card-mod](https://github.com/thomasloven/lovelace-card-mod) card:

### Example:

```yaml
  - type: 'custom:simple-thermostat'
    entity: climate.living_room
    style: |
      ha-card {
        --st-mode-background: #00000018;
      }
```

### After:

![image](https://user-images.githubusercontent.com/23156476/68518802-fdcdf900-028d-11ea-926d-63a0012a08fc.png)

