### PR TITLE
Fix temperature control icons for 0.110

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -397,13 +397,13 @@ class SimpleThermostat extends LitElement {
             return html`
               <div class="main">
                 <div class="current-wrapper ${stepLayout}">
-                  <paper-icon-button
+                  <ha-icon-button
                     ?disabled=${maxTemp && value >= maxTemp}
                     class="thermostat-trigger"
                     icon=${row ? ICONS.PLUS : ICONS.UP}
                     @click="${() => this.setTemperature(this._stepSize, field)}"
                   >
-                  </paper-icon-button>
+                  </ha-icon-button>
 
                   <div
                     @click=${() => this.openEntityPopover()}
@@ -418,14 +418,14 @@ class SimpleThermostat extends LitElement {
                     </h3>
                     <span class="current--unit">${unit}</span>
                   </div>
-                  <paper-icon-button
+                  <ha-icon-button
                     ?disabled=${minTemp && value <= minTemp}
                     class="thermostat-trigger"
                     icon=${row ? ICONS.MINUS : ICONS.DOWN}
                     @click="${() =>
                       this.setTemperature(-this._stepSize, field)}"
                   >
-                  </paper-icon-button>
+                  </ha-icon-button>
                 </div>
               </div>
             `


### PR DESCRIPTION
This *should* fix the issue for icons not displaying in 0.110 due to the new icon loading changes. This follows the same formatting as the change made here: https://github.com/home-assistant/frontend/commit/0a92c28bac80a0bddc3f54577fc62670f3974c15#diff-873f41cce3df4d28dd685519a4e87d01L135