### PR TITLE
fix sensor labels alignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -524,7 +524,7 @@ class SimpleThermostat extends LitElement {
       }
       valueCell = html`
         <div
-          class="clickable"
+          class="sensor-value clickable"
           @click="${() => this.openEntityPopover(state.entity_id)}"
         >
           ${value} ${unit || state.attributes.unit_of_measurement}
@@ -532,7 +532,7 @@ class SimpleThermostat extends LitElement {
       `
     } else {
       valueCell = html`
-        <div>${state}</div>
+        <div class="sensor-value">${state}</div>
       `
     }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -49,12 +49,19 @@ ha-card.no-header {
     var(--paper-font-subhead_-_font-size, 16px)
   );
 }
+.sensor-value {
+  display: flex;
+  align-items: center;
+  padding-bottom: 4px;
+}
 .sensor-heading {
-  text-align: right;
   font-weight: 300;
   padding-right: 8px;
   padding-bottom: 4px;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 .sensors:empty {
   display: none;


### PR DESCRIPTION
Hi @nervetattoo,
first of all, thank you so much for developing this awesome custom card. I've been using it for a couple of months and it looks so cool! :rocket: 

By the way, I recently noticed a tiny issue in the alignment of sensors title/icon and their value, as you can see in the picture below.

![simple-thermostat-before](https://user-images.githubusercontent.com/30753195/86609337-1f61ba80-bfac-11ea-8ce5-1e6c4a4b68ec.jpeg)

The sensor title and its value are not vertically aligned, and there's a little gap between the content of the two divs, which is more evident when using icons instead of text (as in the third row).
I managed to solve it by applying some CSS to the `sensor-heading` and `sensor-value` divs. The result is the following:

![simple-thermostat-after](https://user-images.githubusercontent.com/30753195/86609497-4b7d3b80-bfac-11ea-8d0c-294ae1a7d5f8.jpeg)

So that the title is perfectly aligned with the sensor value. 

This issue is not a big deal, but it's a pity to experience it in such a great lovelace component. :smile: 