### PR TITLE
Added toggle_entity header option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ resources:
 ## Available configuration options:
 
 - `entity` _string_: The thermostat entity id **required**
+- `toggle_entity` _string_: An entity id to create a toggle in the header for. This gives the option to control a separate entity which can be related to the thermostat entity (like a switch, or input_boolean)
 - `name` _string|false_: Override the card name, or disable showing a name at all. Default is to use the friendly_name of the thermostat provided
 - `decimals` _number_: Specify number of decimals to use: 1 or 0
 - `fallback` _string_: Specify a text to display if a valid set point can't be determined. Defaults to `N/A`

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const STEP_SIZE = 0.5
 const DECIMALS = 1
 const UPDATE_PROPS = [
   'entity',
+  'toggle_entity',
   'sensors',
   '_values',
   '_updatingValues',
@@ -118,6 +119,7 @@ class SimpleThermostat extends LitElement {
       _hass: Object,
       config: Object,
       entity: Object,
+      toggle_entity: Object,
       sensors: Array,
       modes: Object,
       icon: String,
@@ -146,6 +148,7 @@ class SimpleThermostat extends LitElement {
 
     this._hass = null
     this.entity = null
+    this.toggle_entity = null
     this.icon = null
     this.sensors = []
     this._stepSize = STEP_SIZE
@@ -178,6 +181,11 @@ class SimpleThermostat extends LitElement {
     this._hass = hass
     if (this.entity !== entity) {
       this.entity = entity
+    }
+
+    const toggle_entity = hass.states[this.config.toggle_entity]
+    if (this.toggle_entity !== toggle_entity) {
+      this.toggle_entity = toggle_entity
     }
 
     const attributes = entity.attributes
@@ -455,6 +463,11 @@ class SimpleThermostat extends LitElement {
           `) ||
           ''}
         <h2 class="header__title">${this.name}</h2>
+        ${(this.toggle_entity && 
+          html`
+            <ha-entity-toggle style="margin-left: auto;" .hass="${this._hass}" .stateObj="${this.toggle_entity}"></ha-entity-toggle>
+          `) ||
+          ''}
       </header>
     `
   }


### PR DESCRIPTION
It will add a switch to header to control a separate toggleable entity (switch, input_boolean, etc).
It can be useful to control related entities to the current thermostat.