### PR TITLE
Fix card height difference between cards with and without toggle_entity

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -430,24 +430,33 @@ class SimpleThermostat extends LitElement {
     }
 
     return html`
-      <header class="clickable" @click=${() => this.openEntityPopover()}>
-        ${(icon &&
-          html`
-            <ha-icon class="header__icon" .icon=${icon}></ha-icon>
-          `) ||
-          ''}
-        <h2 class="header__title">${this.name}</h2>
+      <header>
+        <header class="clickable" @click=${() => this.openEntityPopover()}>
+          ${(icon &&
+            html`
+              <ha-icon class="header__icon" .icon=${icon}></ha-icon>
+            `) ||
+            ''}
+          <h2 class="header__title">${this.name}</h2>
+        </header>
         ${(this.toggle_entity &&
           html`
-            <ha-entity-toggle
+            <ha-switch
               style="margin-left: auto;"
-              .hass="${this._hass}"
-              .stateObj="${this.toggle_entity}"
-            ></ha-entity-toggle>
+              .checked=${this.toggle_entity.state === "on"}
+              @change=${this.toggleEntityChanged}
+            ></ha-switch>
           `) ||
           ''}
       </header>
     `
+  }
+
+  toggleEntityChanged(ev) {
+    const newVal = ev.target.checked;
+    this._hass.callService('homeassistant', newVal ? 'turn_on' : 'turn_off', {
+      entity_id: this.toggle_entity.entity_id
+    });
   }
 
   renderSensors({ _hide, entity, sensors } = this) {

--- a/src/index.js
+++ b/src/index.js
@@ -431,14 +431,14 @@ class SimpleThermostat extends LitElement {
 
     return html`
       <header>
-        <header class="clickable" @click=${() => this.openEntityPopover()}>
+        <div style="display: flex;" class="clickable" @click=${() => this.openEntityPopover()}>
           ${(icon &&
             html`
               <ha-icon class="header__icon" .icon=${icon}></ha-icon>
             `) ||
             ''}
           <h2 class="header__title">${this.name}</h2>
-        </header>
+        </div>
         ${(this.toggle_entity &&
           html`
             <ha-switch


### PR DESCRIPTION
Fix card height difference between cards with toggle_entity and cards without toggle_entity:.
Before:
![simple_thermostat_before](https://user-images.githubusercontent.com/47672949/97326252-7c93bb80-187c-11eb-984a-1ed161306b8d.jpg)

After:
![simple_thermostat_after](https://user-images.githubusercontent.com/47672949/97326286-84536000-187c-11eb-94bd-266be536e899.jpg)
