### PR TITLE
Coloured backgrounds for mode buttons

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -537,7 +537,7 @@ class SimpleThermostat extends LitElement {
         ${list.map(
           ({ value, icon, name }) => html`
             <div
-              class="mode-item ${value === mode ? 'active' : ''}"
+              class="mode-item ${value === mode ? 'active ' + mode : ''}"
               @click=${() => this.setMode(type, value)}
             >
               ${maybeRenderIcon(icon)} ${maybeRenderName(name)}

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,15 @@ ha-card {
   line-height: var(--paper-font-body1_-_line-height);
 
   padding-bottom: calc(var(--st-spacing, var(--st-default-spacing)) * 2);
+
+  --auto-color: green;
+  --heat_cool-color: springgreen;
+  --cool-color: #2b9af9;
+  --heat-color: #ff8100;
+  --manual-color: #44739e;
+  --off-color: #8a8a8a;
+  --fan_only-color: #8a8a8a;
+  --dry-color: #efbd07;
 }
 
 ha-card.no-header {
@@ -163,6 +172,29 @@ header {
     background: var(--st-mode-active-background, var(--primary-color));
     color: var(--st-mode-active-color, var(--text-primary-color));
   }
+
+  &.active.off {
+    background: var(--off-color);
+  }
+  &.active.heat {
+    background: var(--heat-color);
+  }
+  &.active.cool {
+    background: var(--cool-color);
+  }
+  &.active.heat_cool {
+    background: var(--heat_cool-color);
+  }
+  &.active.auto {
+    background: var(--auto-color);
+  }
+  &.active.dry {
+    background: var(--dry-color);
+  }
+  &.active.fan_only {
+    background: var(--fan_only-color);
+  }
+
 }
 .mode-icon {
   --iron-icon-width: 24px;


### PR DESCRIPTION
I've got four simple-thermostat cards stacked.  It's useful to see at a quick glance which units are turned on (and sucking power).

- Colours are taken from the builtin [Thermostat Card](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/hui-thermostat-card.ts)
-  Tested in light mode, dark mode and with the Synthwave theme