### PR TITLE
Icon improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,20 @@ resources:
 - `unit` _string|bool_: Override the unit to display. Set to false to hide unit
 - `decimals` _number_: Specify number of decimals to use: 1 or 0
 - `fallback` _string_: Specify a text to display if a valid set point can't be determined. Defaults to `N/A`
-- `icon` _string|object_: Show an icon next to the card name. You can also pass an object to specify state-specific icons. Defaults state-specific icons radiator/radiator-disabled/snowflake
-  - `idle`: _string_: Use this icon for state idle
-  - `heating`: _string_ Use this icon for state heating
-  - `cool`: _string_ Use this icon for state cool
+- `icon` _string|object_: Show an icon next to the card name. You can also pass an object to specify specific icons. Current value is taken from attributes.hvac_action when available, or state as fallback.
+  - `auto`: _string_ Use this icon for hvac_action auto. Default mdi:radiator
+  - `cooling`: _string_ Use this icon for hvac_action cooling. Default mdi:snowflake
+  - `fan`: _string_ Use this icon for hvac_action fan. Default mdi:fan
+  - `heating`: _string_ Use this icon for hvac_action heating. Default mdi:radiator
+  - `idle`: _string_: Use this icon for hvac_action idle. Default mdi:radiator-disabled
+  - `"off"`: _string_ Use this icon for hvac_action off. Default mdi:radiator-off
+  - `auto`: _string_ Use this icon for state auto. Default hass:autorenew
+  - `cool`: _string_ Use this icon for state cooling. Default hass:snowflake
+  - `dry`: _string_: Use this icon for state dry. Default hass:water-percent
+  - `fan_only`: _string_ Use this icon for state fan. Default hass:fan
+  - `heat`: _string_ Use this icon for state heat. Default hass:autorenew
+  - `heat_cool`: _string_: Use this icon for state heat_cool. Default hass:fire
+  - `"off"`: _string_ Use this icon for state off. Default hass:power
 - `step_size` _number_: Override the default 0.5 step size for increasing/decreasing the temperature
 - `step_layout` _string_: `row` or `column` (default). Using `row` will make the card more compact
 - `label` _object_: Override untranslated labels

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const ICONS = {
   MINUS: 'mdi:minus',
 }
 
-const modeIcons = {
+const MODE_ICONS = {
   off: 'hass:power',
   auto: 'hass:autorenew',
   heat: 'hass:fire',
@@ -102,7 +102,7 @@ function getModeList(type, attributes, config = {}) {
       const { include, ...values } =
         typeof config[name] === 'object' ? config[name] : {}
       return {
-        icon: modeIcons[name],
+        icon: MODE_ICONS[name],
         value: name,
         name,
         ...values,

--- a/src/index.js
+++ b/src/index.js
@@ -50,13 +50,13 @@ const ICONS = {
 }
 
 const MODE_ICONS = {
-  off: 'hass:power',
   auto: 'hass:autorenew',
-  heat: 'hass:fire',
-  heat_cool: 'hass:autorenew',
   cool: 'hass:snowflake',
-  fan_only: 'hass:fan',
   dry: 'hass:water-percent',
+  fan_only: 'hass:fan',
+  heat_cool: 'hass:autorenew',
+  heat: 'hass:fire',
+  off: 'hass:power',
 }
 
 const STATE_ICONS = {

--- a/src/index.js
+++ b/src/index.js
@@ -60,11 +60,12 @@ const modeIcons = {
 }
 
 const STATE_ICONS = {
-  off: 'mdi:radiator-off',
-  idle: 'mdi:radiator-disabled',
-  heating: 'mdi:radiator',
-  cool: 'mdi:snowflake',
   auto: 'mdi:radiator',
+  cooling: 'mdi:snowflake',
+  fan: 'mdi:fan',
+  heating: 'mdi:radiator',
+  idle: 'mdi:radiator-disabled',
+  off: 'mdi:radiator-off',
 }
 
 const DEFAULT_HIDE = {

--- a/src/index.js
+++ b/src/index.js
@@ -283,7 +283,11 @@ class SimpleThermostat extends LitElement {
     if (typeof this.config.icon !== 'undefined') {
       this.icon = this.config.icon
     } else {
-      this.icon = STATE_ICONS
+      if (this.entity.attributes.hvac_action) {
+        this.icon = STATE_ICONS
+      } else {
+        this.icon = MODE_ICONS
+      }
     }
 
     if (this.config.step_size) {
@@ -427,7 +431,7 @@ class SimpleThermostat extends LitElement {
     if (this.name === false) return ''
 
     let icon = this.icon
-    const { hvac_action: action } = this.entity.attributes
+    const action = this.entity.attributes.hvac_action || this.entity.state
     if (typeof this.icon === 'object') {
       icon = action in this.icon ? this.icon[action] : false
     }


### PR DESCRIPTION
Update icons to latest homeassistant hvac_action constants (#132)
Use entity state for icon selection when no hvac_action attribute is present on the entity