### PR TITLE
Narrow View Optimization

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -37,7 +37,7 @@ ha-card.no-header {
 .body {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: 1fr;
+  grid-auto-columns: auto;
   place-items: center;
   padding: 0 calc(var(--st-spacing, var(--st-default-spacing)) * 4);
   padding-bottom: calc(var(--st-spacing, var(--st-default-spacing)) * 2);
@@ -45,7 +45,7 @@ ha-card.no-header {
 
 .sensors {
   display: grid;
-  grid: auto-flow / 1fr 2fr;
+  grid: auto-flow / auto auto;
   grid-gap: var(--st-spacing, var(--st-default-spacing));
   font-size: var(
     --st-font-size-sensors,


### PR DESCRIPTION
Hello, in narrow views (e.g. on a mobile phone), the layout of the card get's broken although there is still unused space. 

Here an example, the minus is displayed below the number although there is still enough place on the left hand side.
![old](https://user-images.githubusercontent.com/25910703/103141931-3338de80-46fc-11eb-9527-0acad06e6cb7.png)

Setting some css parameters to auto will use all available space.
![new](https://user-images.githubusercontent.com/25910703/103141952-8c087700-46fc-11eb-917a-fd06dd7798b0.png)

Looking forward for your comments!
