### PR TITLE
Display 'not available' notification in standard layout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -370,9 +370,9 @@ class SimpleThermostat extends LitElement {
   ) {
     if (!entity) {
       return html`
-        <ha-card class="not-found">
-          Entity not available: <strong class="name">${config.entity}</strong>
-        </ha-card>
+        <hui-warning>
+          Entity not available: ${config.entity}
+        </hui-warning>
       `
     }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,12 +28,6 @@ ha-card.no-header {
   padding: calc(var(--st-spacing, var(--st-default-spacing)) * 4) 0;
 }
 
-.not-found {
-  flex: 1;
-  background-color: yellow;
-  padding: calc(var(--st-spacing, var(--st-default-spacing)) * 4);
-}
-
 .body {
   display: grid;
   grid-auto-flow: column;


### PR DESCRIPTION
For the time being the error 'not available' is displayed with a yellow background and the standard font colour of the theme. In my case, the theme font colour is white which was not readable any more. 

![Unbenannt](https://user-images.githubusercontent.com/25910703/103248400-bcede380-496a-11eb-9211-ad69487da0f9.png)

This pull request removes the 'not-found' class and uses the standard home assistant class. New layout is as follows:

![Unbenannt](https://user-images.githubusercontent.com/25910703/103248517-2e2d9680-496b-11eb-8627-ae624915266a.png)
