### PR TITLE
Correct Hacx installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Home Assistant 0.84 or higher
 1. Install via [HACS](https://hacs.xyz/).
 2. Add to resources:
     ```yaml
-   url: /local/community/simple-thermostat.js?v=1
+   url: /hacsfiles/simple-thermostat/simple-thermostat.js
    type: module
     ```
 


### PR DESCRIPTION
In the hacx installation it says to use the url: ```/hacsfiles/simple-thermostat/simple-thermostat.js``` which it correct, but on github it says to use the url: ```/local/community/simple-thermostat.js?v=1``` which does not work.