### PR TITLE
Only show state string if hvac_action is empty

### DIFF
--- a/src/components/sensors.ts
+++ b/src/components/sensors.ts
@@ -20,12 +20,15 @@ export default function renderSensors({
     type: 'table',
     labels: true,
   }
-  const stateString = [
-    localize(action, 'state_attributes.climate.hvac_action.'),
-    ' (',
-    localize(state, 'component.climate.state._.'),
-    ')',
-  ].join('')
+  var stateString = localize(state, 'component.climate.state._.')
+  if (action) {
+    stateString = [
+      localize(action, 'state_attributes.climate.hvac_action.'),
+      ' (',
+      stateString,
+      ')',
+    ].join('')
+  }
   const sensorHtml = [
     renderInfoItem({
       hide: _hide.temperature,


### PR DESCRIPTION
My climate entities (using the evohome integration) never have the hvac_action attribute set, thus the current state shows as "(Off)" or "(Heat)".

This change removes the brackets (and space) if the hvac_action attribute was empty.