### PR TITLE
fix icons not showing in new HA release

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -431,6 +431,7 @@ export default class SimpleThermostat extends LitElement {
                   icon=${row ? ICONS.PLUS : ICONS.UP}
                   @click="${() => this.setTemperature(this.stepSize, field)}"
                 >
+                  <ha-icon .icon=${row ? ICONS.PLUS : ICONS.UP}></ha-icon>
                 </ha-icon-button>
 
                 <h3
@@ -450,6 +451,7 @@ export default class SimpleThermostat extends LitElement {
                   icon=${row ? ICONS.MINUS : ICONS.DOWN}
                   @click="${() => this.setTemperature(-this.stepSize, field)}"
                 >
+                  <ha-icon .icon=${row ? ICONS.MINUS : ICONS.DOWN}></ha-icon>
                 </ha-icon-button>
               </div>
             `


### PR DESCRIPTION
fix #282

Breaking changes made to the new HA version in the `ha-icon-button` element, causes the media buttons to not show up. This PR fixed that issue while maintaining backward compatibility. I tested it locally on my hass instance.
You can see the change here:

https://github.com/home-assistant/frontend/blob/master/src/components/ha-icon-button.ts#L10-L11

https://github.com/home-assistant/frontend/commit/0c940be5fb002f7df938055997d2be71d6e50903#diff-b7749fac30d4d29a769a04d77d9e72093cfdfecd6e325fba66649575229bde9c
