### PR TITLE
Decrease the temperature debounce

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ interface HANode extends Element {
   hass: any
 }
 
-const DEBOUNCE_TIMEOUT = 1000
+const DEBOUNCE_TIMEOUT = 500
 const STEP_SIZE = 0.5
 const DECIMALS = 1
 


### PR DESCRIPTION
Decrease the debounce to a more sensible 0.5sec; 1sec feels like the UI is becoming unresponsive (and could cause issues when quickly changing the temperature before closing the tab)